### PR TITLE
Add support for reading css and javascript files from a component directory

### DIFF
--- a/tetra/apps.py
+++ b/tetra/apps.py
@@ -15,11 +15,11 @@ def watch_extra_files(sender, *args, **kwargs):
     for app_name, library in libraries.items():
         for lib_name, library_info in library.items():
             if library_info:
-                watch_list = glob(f"{library_info.path}/**/*.html", recursive=True)
+                # watch for html, js, and css files
+                watch_list = glob(f"{library_info.path}/**/*.*", recursive=True)
                 for file in watch_list:
-                    if os.path.exists(file):
+                    if os.path.exists(file) and file.endswith(('.html', '.css', '.js')):
                         watch(Path(file))
-
 
 class TetraConfig(AppConfig):
     name = "tetra"

--- a/tetra/components/base.py
+++ b/tetra/components/base.py
@@ -247,9 +247,9 @@ class BasicComponent(metaclass=BasicComponentMetaClass):
             start = py_source.index(cls.style, comp_start_offset)
             before = py_source[:start]
             before = re.sub(f"\S", " ", before)
-            return f"{before}{cls.style}"
+            return f"{before}{cls.style}", True
         else:
-            return cls._read_component_file_with_extension("css")
+            return cls._read_component_file_with_extension("css"), False
 
     @classmethod
     def as_tag(cls, _request, *args, **kwargs):
@@ -538,10 +538,10 @@ class Component(BasicComponent, metaclass=ComponentMetaClass):
             start = py_source.index(cls.script, comp_start_offset)
             before = py_source[:start]
             before = re.sub(f"\S", " ", before)
-            return f"{before}{cls.script}"
+            return f"{before}{cls.script}", True
         else:
             # Find script in the component's directory
-            return cls._read_component_file_with_extension("js")
+            return cls._read_component_file_with_extension("js"), False
 
 
     def _call_load(self, *args, **kwargs):

--- a/tetra/components/base.py
+++ b/tetra/components/base.py
@@ -55,7 +55,7 @@ def make_template(cls) -> Template:
     from ..templatetags.tetra import get_nodes_by_type_deep
 
     # if only "template" is defined, use it as inline template string.
-    if hasattr(cls, "template"):
+    if bool(hasattr(cls, "template") and cls.template):
         making_lazy_after_exception = False
         filename, line = cls.get_template_source_location()
         origin = InlineOrigin(
@@ -192,6 +192,26 @@ class BasicComponent(metaclass=BasicComponentMetaClass):
         line = source[:start].count("\n") + 1
         return filename, line
 
+
+    @classmethod
+    def _get_component_file_path_with_extension(cls, extension):
+        module = importlib.import_module(cls.__module__)
+        component_name = module.__name__.split(".")[-1]
+        module_path = module.__path__[0]
+        file_name = f"{component_name}.{extension}"
+        return os.path.join(module_path, file_name)
+
+    @classmethod
+    def _read_component_file_with_extension(cls, extension):
+        file_path = cls._get_component_file_path_with_extension(extension)
+        if os.path.exists(file_path):
+            try:
+                with open(file_path, "r") as f:
+                    return f.read()
+            except FileNotFoundError:
+                return ""
+        else:
+            return ""
     @classmethod
     def has_script(cls):
         return False
@@ -203,22 +223,33 @@ class BasicComponent(metaclass=BasicComponentMetaClass):
 
     @classmethod
     def has_styles(cls):
-        return bool(hasattr(cls, "style") and cls.style)
+        if bool(hasattr(cls, "style") and cls.style):
+            return True
+        else:
+            return os.path.exists(cls._get_component_file_path_with_extension("css"))
 
     @classmethod
     def make_styles(cls):
-        return cls.style
+        # check if the style is defined in the class otherwise check if there is a file in the component directory
+        if bool(hasattr(cls, "style") and cls.style):
+            return cls.style
+        else:
+            return cls._read_component_file_with_extension("css")
 
     @classmethod
     def make_styles_file(cls):
-        filename, comp_start_line, source_len = cls.get_source_location()
-        with open(filename, "r") as f:
-            py_source = f.read()
-        comp_start_offset = len("\n".join(py_source.split("\n")[:comp_start_line]))
-        start = py_source.index(cls.style, comp_start_offset)
-        before = py_source[:start]
-        before = re.sub(f"\S", " ", before)
-        return f"{before}{cls.style}"
+        # check if we have a style defined in the class otherwise check if there is a file in the component directory
+        if bool(hasattr(cls, "style") and cls.style):
+            filename, comp_start_line, source_len = cls.get_source_location()
+            with open(filename, "r") as f:
+                py_source = f.read()
+            comp_start_offset = len("\n".join(py_source.split("\n")[:comp_start_line]))
+            start = py_source.index(cls.style, comp_start_offset)
+            before = py_source[:start]
+            before = re.sub(f"\S", " ", before)
+            return f"{before}{cls.style}"
+        else:
+            return cls._read_component_file_with_extension("css")
 
     @classmethod
     def as_tag(cls, _request, *args, **kwargs):
@@ -463,7 +494,11 @@ class Component(BasicComponent, metaclass=ComponentMetaClass):
 
     @classmethod
     def has_script(cls):
-        return bool(cls.script)
+        # check if the script is defined in the class otherwise check if there is a file in the component directory
+        if bool(hasattr(cls, "script") and cls.script):
+            return True
+        else:
+            return os.path.exists(cls._get_component_file_path_with_extension("js"))
 
     @classmethod
     def _component_url(cls, method_name):
@@ -495,14 +530,19 @@ class Component(BasicComponent, metaclass=ComponentMetaClass):
 
     @classmethod
     def make_script_file(cls):
-        filename, comp_start_line, source_len = cls.get_source_location()
-        with open(filename, "r") as f:
-            py_source = f.read()
-        comp_start_offset = len("\n".join(py_source.split("\n")[:comp_start_line]))
-        start = py_source.index(cls.script, comp_start_offset)
-        before = py_source[:start]
-        before = re.sub(f"\S", " ", before)
-        return f"{before}{cls.script}"
+        if bool(hasattr(cls, "script") and cls.script):
+            filename, comp_start_line, source_len = cls.get_source_location()
+            with open(filename, "r") as f:
+                py_source = f.read()
+            comp_start_offset = len("\n".join(py_source.split("\n")[:comp_start_line]))
+            start = py_source.index(cls.script, comp_start_offset)
+            before = py_source[:start]
+            before = re.sub(f"\S", " ", before)
+            return f"{before}{cls.script}"
+        else:
+            # Find script in the component's directory
+            return cls._read_component_file_with_extension("js")
+
 
     def _call_load(self, *args, **kwargs):
         self._load_args = args

--- a/tetra/library.py
+++ b/tetra/library.py
@@ -118,10 +118,13 @@ class Library:
             for component_name, component in self.components.items():
                 print(f" - {component_name}")
                 if component.has_script():
-                    script = component.make_script_file()
+                    script, is_inline = component.make_script_file()
                     py_filename, _, _ = component.get_source_location()
                     py_dir = os.path.dirname(py_filename)
-                    filename = f"{os.path.basename(py_filename)}__{component_name}.js"
+                    if is_inline:
+                        filename = f"{os.path.basename(py_filename)}__{component_name}.js"
+                    else:
+                        filename = f"{component_name}.js"
                     component_path = os.path.join(py_dir, filename)
                     files_to_remove.append(component_path)
                     with open(component_path, "w") as f:
@@ -173,10 +176,13 @@ class Library:
             for component_name, component in self.components.items():
                 if component.has_styles():
                     print(f" - {component_name}")
-                    styles = component.make_styles_file()
+                    styles, is_inline = component.make_styles_file()
                     py_filename, _, _ = component.get_source_location()
                     py_dir = os.path.dirname(py_filename)
-                    filename = f"{os.path.basename(py_filename)}__{component_name}.css"
+                    if is_inline:
+                        filename = f"{os.path.basename(py_filename)}__{component_name}.css"
+                    else:
+                        filename = f"{component_name}.css"
                     component_path = os.path.join(py_dir, filename)
                     files_to_remove.append(component_path)
                     with open(component_path, "w") as f:


### PR DESCRIPTION
Component as dirs now fully working with js and css files correctly loaded if the file exists. The inline script or javascript tag will take precedence, otherwise the file will be used. Autoreload watcher also updated to check for js and css files to trigger a rebuild/reload.