### PR TITLE
Set a default key for a component

### DIFF
--- a/tetra/components/base.py
+++ b/tetra/components/base.py
@@ -443,7 +443,7 @@ class Component(BasicComponent, metaclass=ComponentMetaClass):
 
     def __init__(self, _request, key=None, *args, **kwargs):
         super().__init__(_request, *args, **kwargs)
-        self.key = key
+        self.key = key if key is not None else self.full_component_name()
 
     @classmethod
     def from_state(

--- a/tetra/templatetags/tetra.py
+++ b/tetra/templatetags/tetra.py
@@ -298,6 +298,8 @@ class ComponentNode(template.Node):
                         blocks[block_name] = new_block
 
         children_state = context.get("_loaded_children_state", None)
+        if "key" not in resolved_kwargs:
+            resolved_kwargs["key"] = Component.full_component_name()
         if children_state and (resolved_kwargs["key"] in children_state):
             component_state = children_state[resolved_kwargs["key"]]
             component = Component.from_state(


### PR DESCRIPTION
See: #86 - there are cases where a component without a key can be refreshed and will end up crashing. This always sets a key to a component if one is not specified.